### PR TITLE
Render sticky header before foreground

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -95,6 +95,7 @@ class ParallaxScrollView extends Component {
       <View style={[style, styles.container]}
             onLayout={(e) => this._maybeUpdateViewDimensions(e)}>
         { background }
+        { maybeStickyHeader }
         {
           React.cloneElement(scrollElement, {
               ref: SCROLLVIEW_REF,
@@ -107,7 +108,6 @@ class ParallaxScrollView extends Component {
             footerSpacer
           )
         }
-        { maybeStickyHeader }
       </View>
     );
   }


### PR DESCRIPTION
This ensures that press events on anything in the foreground are recognised.